### PR TITLE
Make ngx-captcha compatible with reactive forms & template-driven forms

### DIFF
--- a/demo/src/demo.module.ts
+++ b/demo/src/demo.module.ts
@@ -2,17 +2,20 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 
-import { NgxCaptchaModule } from '../../projects/ngx-captcha-lib/src/public_api';
+import { NgxCaptchaModule } from '../../projects/ngx-captcha-lib/src/lib';
 import { DemoComponent } from './demo.component';
 import { DemoRoutes } from './demo.routes';
 import { InstallationComponent } from './installation.component';
 import { InvisibleReCaptchaDemoComponent } from './invisible-recaptcha-demo.component';
 import { ReCaptcha2DemoComponent } from './re-captcha-2-demo.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   imports: [
     RouterModule,
     BrowserModule,
+    FormsModule,
+    ReactiveFormsModule,
     NgxCaptchaModule.forRoot({
       reCaptcha2SiteKey: '6LcvoUgUAAAAAJJbhcXvLn3KgG-pyULLusaU4mL1',
       invisibleCaptchaSiteKey: '6LckpEgUAAAAACPcjmrg1Es-GnTltKx0MP61FBO8'

--- a/demo/src/invisible-recaptcha-demo.component.html
+++ b/demo/src/invisible-recaptcha-demo.component.html
@@ -1,4 +1,3 @@
-
 <div class="row featurette">
     <div class="col-md-7">
         <h2 class="featurette-heading">Invisible reCAPTCHA
@@ -90,7 +89,7 @@
     </div>
     <div class="col-md-5">
         <h4>Live example</h4>
-        <ngx-invisible-recaptcha #captchaElem (ready)="handleReady()" (load)="handleLoad()" (success)="handleSuccess($event)" [type]="type" [badge]="badge">
+        <ngx-invisible-recaptcha #captchaElem (ready)="handleReady()" (load)="handleLoad()" (success)="handleSuccess($event)" [type]="type" [badge]="badge" [ngModel]="recaptcha" [ngModelOptions]="{standalone: true}">
         </ngx-invisible-recaptcha>
 
         <h4 class="mt-3">Status</h4>

--- a/demo/src/invisible-recaptcha-demo.component.ts
+++ b/demo/src/invisible-recaptcha-demo.component.ts
@@ -26,12 +26,13 @@ export class InvisibleReCaptchaDemoComponent implements AfterViewInit {
   public badge: 'bottomright' | 'bottomleft' | 'inline' = 'inline';
   public type: 'image' | 'audio';
 
+  protected recaptcha: any = null;
+
   @ViewChild('captchaElem') captchaElem: InvisibleReCaptchaComponent;
   @ViewChild('langInput') langInput: ElementRef;
 
 
-  constructor(private cdr: ChangeDetectorRef) {
-  }
+  constructor(private cdr: ChangeDetectorRef) {}
 
   ngAfterViewInit(): void {
       this.captchaIsLoaded = true;

--- a/demo/src/re-captcha-2-demo.component.html
+++ b/demo/src/re-captcha-2-demo.component.html
@@ -1,132 +1,134 @@
-<div class="row featurette">
-    <div class="col-md-7">
-        <h2 class="featurette-heading">Google reCAPTCHA2
-        </h2>
+<form action="" [formGroup]="aFormGroup">
+  <div class="row featurette">
+      <div class="col-md-7">
+          <h2 class="featurette-heading">Google reCAPTCHA2
+          </h2>
 
-        <p class="mt-4">
-            This is a completely dynamic implementation - try changing properties to immediately see changes in rendered captcha.
-        </p>
+          <p class="mt-4">
+              This is a completely dynamic implementation - try changing properties to immediately see changes in rendered captcha.
+          </p>
 
-        <table class="table mt-3">
-            <thead>
-                <tr>
-                    <th>Property</th>
-                    <th>Values</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Theme</td>
-                    <td>
-                        <span style="cursor:pointer" class="text-primary" (click)="changeTheme('light')">Light</span> |
-                        <span style="cursor:pointer" class="text-primary" (click)="changeTheme('dark')">Dark</span>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Language</td>
-                    <td>
-                        <div class="input-group">
-                            <input type="text" class="form-control" placeholder="Culture code (i.e. 'en', 'es')" #langInput [value]="lang">
-                            <div class="input-group-append">
-                                <button class="btn btn-info" (click)="setLanguage()">Set</button>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Size</td>
-                    <td>
-                        <span style="cursor:pointer" class="text-primary" (click)="changeSize('compact')">Compact</span> |
-                        <span style="cursor:pointer" class="text-primary" (click)="changeSize('normal')">Normal</span>
-                    </td>
-                </tr>
-                <tr>
-                    <td>Type</td>
-                    <td>
-                        <span style="cursor:pointer" class="text-primary" (click)="changeType('image')">Image</span> |
-                        <span style="cursor:pointer" class="text-primary" (click)="changeType('audio')">Audio</span>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+          <table class="table mt-3">
+              <thead>
+                  <tr>
+                      <th>Property</th>
+                      <th>Values</th>
+                  </tr>
+              </thead>
+              <tbody>
+                  <tr>
+                      <td>Theme</td>
+                      <td>
+                          <span style="cursor:pointer" class="text-primary" (click)="changeTheme('light')">Light</span> |
+                          <span style="cursor:pointer" class="text-primary" (click)="changeTheme('dark')">Dark</span>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>Language</td>
+                      <td>
+                          <div class="input-group">
+                              <input type="text" class="form-control" placeholder="Culture code (i.e. 'en', 'es')" #langInput [value]="lang">
+                              <div class="input-group-append">
+                                  <button class="btn btn-info" (click)="setLanguage()">Set</button>
+                              </div>
+                          </div>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>Size</td>
+                      <td>
+                          <span style="cursor:pointer" class="text-primary" (click)="changeSize('compact')">Compact</span> |
+                          <span style="cursor:pointer" class="text-primary" (click)="changeSize('normal')">Normal</span>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>Type</td>
+                      <td>
+                          <span style="cursor:pointer" class="text-primary" (click)="changeType('image')">Image</span> |
+                          <span style="cursor:pointer" class="text-primary" (click)="changeType('audio')">Audio</span>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
 
-        <table class="table mt-3">
-            <thead>
-                <tr>
-                    <th>Method</th>
-                    <th>Description</th>
-                    <th>Action</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>getCurrentResponse</td>
-                    <td>Gets the latest submitted response</td>
-                    <td>
-                        <button class="btn btn-info" (click)="getCurrentResponse()">Try</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>getResponse</td>
-                    <td>Gets captcha response</td>
-                    <td>
-                        <button class="btn btn-info" (click)="getResponse()">Try</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>reset</td>
-                    <td>Resets captcha (does not reload script)</td>
-                    <td>
-                        <button class="btn btn-info" (click)="reset()">Try</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>reload</td>
-                    <td>Unsets global script & reloads captcha</td>
-                    <td>
-                        <button class="btn btn-info" (click)="reload()">Try</button>
-                    </td>
-                </tr>
-                <tr>
-                    <td>getCaptchaId</td>
-                    <td>Gets Id of captcha</td>
-                    <td>
-                        <button class="btn btn-info" (click)="getCaptchaId()">Try</button>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <div class="col-md-5">
-        <h4>Live example</h4>
-        <ngx-recaptcha2 #captchaElem (expire)="handleExpire()" (load)="handleLoad()" (success)="handleSuccess($event)" [size]="size"
-            [hl]="lang" [theme]="theme" [type]="type"></ngx-recaptcha2>
+          <table class="table mt-3">
+              <thead>
+                  <tr>
+                      <th>Method</th>
+                      <th>Description</th>
+                      <th>Action</th>
+                  </tr>
+              </thead>
+              <tbody>
+                  <tr>
+                      <td>getCurrentResponse</td>
+                      <td>Gets the latest submitted response</td>
+                      <td>
+                          <button class="btn btn-info" (click)="getCurrentResponse()">Try</button>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>getResponse</td>
+                      <td>Gets captcha response</td>
+                      <td>
+                          <button class="btn btn-info" (click)="getResponse()">Try</button>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>reset</td>
+                      <td>Resets captcha (does not reload script)</td>
+                      <td>
+                          <button class="btn btn-info" (click)="reset()">Try</button>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>reload</td>
+                      <td>Unsets global script & reloads captcha</td>
+                      <td>
+                          <button class="btn btn-info" (click)="reload()">Try</button>
+                      </td>
+                  </tr>
+                  <tr>
+                      <td>getCaptchaId</td>
+                      <td>Gets Id of captcha</td>
+                      <td>
+                          <button class="btn btn-info" (click)="getCaptchaId()">Try</button>
+                      </td>
+                  </tr>
+              </tbody>
+          </table>
+      </div>
+      <div class="col-md-5">
+          <h4>Live example</h4>
+          <ngx-recaptcha2 #captchaElem (expire)="handleExpire()" (load)="handleLoad()" (success)="handleSuccess($event)" [size]="size"
+              [hl]="lang" [theme]="theme" [type]="type" formControlName="recaptcha"></ngx-recaptcha2>
 
-        <h4 class="mt-3">Status</h4>
-        <div>
-            <ul class="alt">
-                <li>
-                    <span>Loaded: </span>
-                    <i *ngIf="!captchaIsLoaded" class="fas fa-times text-danger"></i>
-                    <i *ngIf="captchaIsLoaded" class="fas fa-check text-success"></i>
-                </li>
-                <li>
-                    <span>Captcha success: </span>
-                    <i *ngIf="!captchaSuccess" class="fas fa-times text-danger"></i>
-                    <i *ngIf="captchaSuccess" class="fas fa-check text-success"></i>
-                </li>
-                <li>
-                    <span>Captcha expired: </span>
-                    <i *ngIf="!captchaIsExpired" class="fas fa-times text-danger"></i>
-                    <i *ngIf="captchaIsExpired" class="fas fa-check text-success"></i>
-                </li>
-            </ul>
-        </div>
+          <h4 class="mt-3">Status</h4>
+          <div>
+              <ul class="alt">
+                  <li>
+                      <span>Loaded: </span>
+                      <i *ngIf="!captchaIsLoaded" class="fas fa-times text-danger"></i>
+                      <i *ngIf="captchaIsLoaded" class="fas fa-check text-success"></i>
+                  </li>
+                  <li>
+                      <span>Captcha success: </span>
+                      <i *ngIf="!captchaSuccess" class="fas fa-times text-danger"></i>
+                      <i *ngIf="captchaSuccess" class="fas fa-check text-success"></i>
+                  </li>
+                  <li>
+                      <span>Captcha expired: </span>
+                      <i *ngIf="!captchaIsExpired" class="fas fa-times text-danger"></i>
+                      <i *ngIf="captchaIsExpired" class="fas fa-check text-success"></i>
+                  </li>
+              </ul>
+          </div>
 
-        <h4 class="mt-3">Code</h4>
+          <h4 class="mt-3">Code</h4>
 
-        <pre class="mt-2">
-            <code [innerText]="exampleCode"></code>
-        </pre>
-    </div>
-</div>
+          <pre class="mt-2">
+              <code [innerText]="exampleCode"></code>
+          </pre>
+      </div>
+  </div>
+</form>

--- a/demo/src/re-captcha-2-demo.component.ts
+++ b/demo/src/re-captcha-2-demo.component.ts
@@ -2,11 +2,12 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
-  ElementRef,
+  ElementRef, OnInit,
   ViewChild
 } from '@angular/core';
 
 import { ReCaptcha2Component } from '../../projects/ngx-captcha-lib/src/public_api';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 declare var hljs: any;
 
@@ -14,7 +15,7 @@ declare var hljs: any;
   selector: 'ngx-recaptcha-2-demo',
   templateUrl: './re-captcha-2-demo.component.html'
 })
-export class ReCaptcha2DemoComponent implements AfterViewInit {
+export class ReCaptcha2DemoComponent implements OnInit, AfterViewInit {
   public readonly installCode = `
   npm install ngx-captcha`;
 
@@ -51,8 +52,15 @@ import { NgxCaptchaModule } from 'ngx-captcha';
 
   @ViewChild('captchaElem') captchaElem: ReCaptcha2Component;
   @ViewChild('langInput') langInput: ElementRef;
+  protected aFormGroup: FormGroup;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.aFormGroup = this.formBuilder.group({
+      recaptcha: ['', Validators.required]
+    });
+  }
 
   ngAfterViewInit(): void {
     this.highlight();

--- a/projects/ngx-captcha-lib/src/lib/base-recaptcha.component.ts
+++ b/projects/ngx-captcha-lib/src/lib/base-recaptcha.component.ts
@@ -343,7 +343,7 @@ export abstract class BaseReCaptchaComponent implements OnChanges, OnDestroy {
         // render captcha
         this.renderReCaptcha();
 
-        // setup component if it was flagges as such
+        // setup component if it was flagged as such
         if (this.setupAfterLoad) {
             this.setupAfterLoad = false;
             this.setupComponent();

--- a/projects/ngx-captcha-lib/src/lib/invisible-recaptcha.component.ts
+++ b/projects/ngx-captcha-lib/src/lib/invisible-recaptcha.component.ts
@@ -1,15 +1,23 @@
-import { Component, Input, OnChanges, Optional, Renderer2, SimpleChanges, NgZone } from '@angular/core';
+import { Component, Input, OnChanges, Optional, Renderer2, SimpleChanges, NgZone, Injector, forwardRef } from '@angular/core';
 
 import { BaseReCaptchaComponent } from './base-recaptcha.component';
 import { ReCaptchaType } from './recaptcha-type.enum';
 import { NgxCaptchaConfig } from './recaptcha.config';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 
 @Component({
   selector: 'ngx-invisible-recaptcha',
   template: `
   <div #captchaScriptElem></div>
-  <div #captchaWrapperElem></div>`
+  <div #captchaWrapperElem></div>`,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => InvisibleReCaptchaComponent),
+      multi: true,
+    }
+  ]
 })
 export class InvisibleReCaptchaComponent extends BaseReCaptchaComponent implements OnChanges {
 
@@ -33,9 +41,10 @@ export class InvisibleReCaptchaComponent extends BaseReCaptchaComponent implemen
   constructor(
     protected renderer: Renderer2,
     protected zone: NgZone,
+    protected injector: Injector,
     @Optional() protected globalConfig: NgxCaptchaConfig,
   ) {
-    super(renderer, zone, globalConfig);
+    super(renderer, zone, injector, globalConfig);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-captcha-lib/src/lib/recaptcha-2.component.ts
+++ b/projects/ngx-captcha-lib/src/lib/recaptcha-2.component.ts
@@ -8,18 +8,26 @@ import {
   Output,
   Renderer2,
   SimpleChanges,
-  NgZone,
+  NgZone, Injector, forwardRef,
 } from '@angular/core';
 
 import { BaseReCaptchaComponent } from './base-recaptcha.component';
 import { ReCaptchaType } from './recaptcha-type.enum';
 import { NgxCaptchaConfig } from './recaptcha.config';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
   selector: 'ngx-recaptcha2',
   template: `
   <div #captchaScriptElem></div>
-  <div #captchaWrapperElem></div>`
+  <div #captchaWrapperElem></div>`,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ReCaptcha2Component),
+      multi: true,
+    }
+  ]
 })
 export class ReCaptcha2Component extends BaseReCaptchaComponent implements OnChanges, OnDestroy {
 
@@ -63,9 +71,10 @@ export class ReCaptcha2Component extends BaseReCaptchaComponent implements OnCha
   constructor(
     protected renderer: Renderer2,
     protected zone: NgZone,
+    protected injector: Injector,
     @Optional() protected globalConfig: NgxCaptchaConfig,
   ) {
-    super(renderer, zone, globalConfig);
+    super(renderer, zone, injector, globalConfig);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -111,6 +120,11 @@ export class ReCaptcha2Component extends BaseReCaptchaComponent implements OnCha
    * Handles error callback
   */
   private handleErrorCallback(): void {
+    this.zone.run(() => {
+      this.onChange(null);
+      this.onTouched(null);
+    });
+
     this.error.next();
   }
 


### PR DESCRIPTION
Thanks for putting in so much work in this component!

To be able to use this component with reactive or template driven forms, I've extended the 
base component and both variants. What I basically did is implemented the required `ControlValueAccessor` methods to bridge the gap between the recaptcha component and the native form element in the DOM.

Furthermore I've extended the demo:
- for the regular mode I've added the reactive forms integration
- for the invisible mode I've added the template driven forms approach

To make this work I hat to introduce a breaking change. The recaptcha component has to be used in the context of reactive forms or template driven forms. Imho that's not a bad think as I think it's a form element and should therefore be used in this context. However, to use this you don't need to add a wrapping form element, just use the the template driven approach and use the `[ngModelOptions]="{standalone: true}`

I'd be happy if you'd take a look and give me some feedback about the changes.

I am not 100% sure if that's the way to go. Would it be better to create a separate module just for the form-related approach?