### PR TITLE
Extend readme and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ npm install ngx-captcha
 ```
 
 Import `NgxCaptchaModule ` to your module (i.e. `AppModule`). You can configure global keys with `forRoot` (optionally) or you can use `siteKey` input parameter of captcha components.
+Depending on whether you want to use [reactive forms](https://angular.io/guide/reactive-forms) or [template-driven forms](https://angular.io/guide/forms) you need to include the appropriate modules, too.
+Add `ReactiveFormsModule` to your imports in case you want to use reactive forms. If you prefer the the template-driven approach simple add the `FormsModule` to your module. 
+Both can be imported from `@angular/forms`. In the demo project you can check out the *normal* demo to see how to use reactive forms or
+the *invisible* demo to see what the template-driven approach looks like. With the template-driven approach you don't necessarily need to use a from element to wrap the component, you can instead use the `[ngModelOptions]="{ standalone: true }"`.
 
 ```javascript
 import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { NgxCaptchaModule } from 'ngx-captcha';
 
 @NgModule({
   imports: [
+    ReactiveFormsModule,
     NgxCaptchaModule.forRoot({
       reCaptcha2SiteKey: 'xxxx', // optional, can be overridden with 'siteKey' component property
       invisibleCaptchaSiteKey: 'yyy' // optional, can be overridden with 'siteKey' component property
@@ -32,30 +38,52 @@ export class AppModule { }
 ```
 
 ## Usage
-
-The configuration properties are a copy of the official ones that google provides. For explanation of what these properties do and how to use them, please refer to [https://developers.google.com/recaptcha/docs/display](https://developers.google.com/recaptcha/docs/display) and [https://developers.google.com/recaptcha/docs/invisible](https://developers.google.com/recaptcha/docs/invisible)
+The configuration properties are a copy of the official ones that google provides. For explanation of what these properties do and how to use them, please refer to [https://developers.google.com/recaptcha/docs/display](https://developers.google.com/recaptcha/docs/display) and [https://developers.google.com/recaptcha/docs/invisible](https://developers.google.com/recaptcha/docs/invisible).
 
 ### reCaptcha2
 
+your.component.ts
+```javascript
+export class YourComponent implements OnInit {
+  protected aFormGroup: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.aFormGroup = this.formBuilder.group({
+      recaptcha: ['', Validators.required]
+    });
+  }
+}
+
+```
+
+your.template.html
 ```html
-<ngx-recaptcha2
-  [size]="size"
-  [hl]="lang"
-  [theme]="theme"
-  [type]="type"
-  (expire)="handleExpire()"
-  (load)="handleLoad()"
-  (success)="handleSuccess($event)">
-</ngx-recaptcha2>
+<form [formGroup]="aFormGroup">
+  <ngx-recaptcha2
+    [size]="size"
+    [hl]="lang"
+    [theme]="theme"
+    [type]="type"
+    (expire)="handleExpire()"
+    (load)="handleLoad()"
+    (success)="handleSuccess($event)"
+    formControlName="recaptcha">
+  </ngx-recaptcha2>
+</form>
 ```
 
 ### Invisible captcha
 
 ```html
-<ngx-invisible-recaptcha
-  [type]="type"
-  [badge]="badge"
-  (load)="handleLoad()"
-  (success)="handleSuccess($event)">
-</ngx-invisible-recaptcha>
+<form [formGroup]="aFormGroup">
+  <ngx-invisible-recaptcha
+    [type]="type"
+    [badge]="badge"
+    (load)="handleLoad()"
+    (success)="handleSuccess($event)"
+    formControlName="recaptcha">
+  </ngx-invisible-recaptcha>
+</form>
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Depending on whether you want to use [reactive forms](https://angular.io/guide/r
 Add `ReactiveFormsModule` to your imports in case you want to use reactive forms. If you prefer the the template-driven approach simple add the `FormsModule` to your module. 
 Both can be imported from `@angular/forms`. In the demo project you can check out the *normal* demo to see how to use reactive forms or
 the *invisible* demo to see what the template-driven approach looks like. With the template-driven approach you don't necessarily need to use a from element to wrap the component, you can instead use the `[ngModelOptions]="{ standalone: true }"`.
+However, using it with the standalone option is not recommended but can be used if needed. 
 
 ```javascript
 import { NgModule } from '@angular/core';

--- a/demo/src/invisible-recaptcha-demo.component.html
+++ b/demo/src/invisible-recaptcha-demo.component.html
@@ -89,7 +89,14 @@
     </div>
     <div class="col-md-5">
         <h4>Live example</h4>
-        <ngx-invisible-recaptcha #captchaElem (ready)="handleReady()" (load)="handleLoad()" (success)="handleSuccess($event)" [type]="type" [badge]="badge" [ngModel]="recaptcha" [ngModelOptions]="{standalone: true}">
+        <ngx-invisible-recaptcha #captchaElem
+                                 (ready)="handleReady()"
+                                 (load)="handleLoad()"
+                                 (success)="handleSuccess($event)"
+                                 [type]="type"
+                                 [badge]="badge"
+                                 [ngModel]="recaptcha"
+                                 [ngModelOptions]="{ standalone: true }">
         </ngx-invisible-recaptcha>
 
         <h4 class="mt-3">Status</h4>

--- a/demo/src/invisible-recaptcha-demo.component.ts
+++ b/demo/src/invisible-recaptcha-demo.component.ts
@@ -14,7 +14,8 @@ export class InvisibleReCaptchaDemoComponent implements AfterViewInit {
   [type]="type"
   [badge]="badge"
   (load)="handleLoad()"
-  (success)="handleSuccess($event)">
+  (success)="handleSuccess($event)"
+  [ngModelOptions]="{ standalone: true }">
 </ngx-invisible-recaptcha>
 `;
 

--- a/demo/src/re-captcha-2-demo.component.html
+++ b/demo/src/re-captcha-2-demo.component.html
@@ -1,4 +1,4 @@
-<form action="" [formGroup]="aFormGroup">
+<form [formGroup]="aFormGroup">
   <div class="row featurette">
       <div class="col-md-7">
           <h2 class="featurette-heading">Google reCAPTCHA2
@@ -100,8 +100,16 @@
       </div>
       <div class="col-md-5">
           <h4>Live example</h4>
-          <ngx-recaptcha2 #captchaElem (expire)="handleExpire()" (load)="handleLoad()" (success)="handleSuccess($event)" [size]="size"
-              [hl]="lang" [theme]="theme" [type]="type" formControlName="recaptcha"></ngx-recaptcha2>
+          <ngx-recaptcha2 #captchaElem
+                          (expire)="handleExpire()"
+                          (load)="handleLoad()"
+                          (success)="handleSuccess($event)"
+                          [size]="size"
+                          [hl]="lang"
+                          [theme]="theme"
+                          [type]="type"
+                          formControlName="recaptcha">
+          </ngx-recaptcha2>
 
           <h4 class="mt-3">Status</h4>
           <div>

--- a/demo/src/re-captcha-2-demo.component.ts
+++ b/demo/src/re-captcha-2-demo.component.ts
@@ -37,7 +37,8 @@ import { NgxCaptchaModule } from 'ngx-captcha';
   [type]="type"
   (expire)="handleExpire()"
   (load)="handleLoad()"
-  (success)="handleSuccess($event)">
+  (success)="handleSuccess($event)"
+  formControlName="recaptcha">
 </ngx-recaptcha2>`;
 
   public captchaIsLoaded = false;


### PR DESCRIPTION
I've updated the readme and the demo to make it easier for others to integrate. I am wondering whether we should remove the `[ngModelOptions]="{ standalone: true }` as a suggestion to avoid using a form. It's more like a `workaround`. So maybe getting rid of this and properly wrapping the component in a form always might be a cleaner solution. It works but was designed for another case by the angular team. Unfortunately, I won't be able to refactor this today but sure can tmrw.

What do you think?

