### PR TITLE
Optional form control

### DIFF
--- a/projects/ngx-captcha-lib/src/lib/components/base-recaptcha.component.ts
+++ b/projects/ngx-captcha-lib/src/lib/components/base-recaptcha.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ElementRef, EventEmitter, Injector, Input, NgZone, OnChanges, Output, Renderer2, SimpleChanges, Directive } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ElementRef, EventEmitter, Injector, InjectFlags, Input, NgZone, OnChanges, Output, Renderer2, SimpleChanges, Directive } from '@angular/core';
 import { ControlValueAccessor, FormControl, NgControl, AbstractControl } from '@angular/forms';
 import { Type } from '@angular/core';
 
@@ -139,7 +139,7 @@ export abstract class BaseReCaptchaComponent implements OnChanges, ControlValueA
     ) { }
 
     ngAfterViewInit() {
-        this.control = this.injector.get<NgControl>(NgControl).control;
+        this.control = this.injector.get<NgControl | undefined>(NgControl, undefined, InjectFlags.Optional)?.control;
     }
 
     ngAfterViewChecked(): void {


### PR DESCRIPTION
We've been using this fork since last year without wrapping `<ngx-recaptcha2>` in a parent form, and as far as I can tell it works as expected.