### PR TITLE
[Fix] Fixed wrong call to registerCaptchaScript with boolean when ask…

### DIFF
--- a/projects/ngx-captcha-lib/src/lib/components/base-recaptcha.component.ts
+++ b/projects/ngx-captcha-lib/src/lib/components/base-recaptcha.component.ts
@@ -314,8 +314,8 @@ export abstract class BaseReCaptchaComponent
     this.createAndSetCaptchaElem();
 
     this.scriptService.registerCaptchaScript(
-      this.useGlobalDomain,
-      "explicit",
+      {useGlobalDomain: this.useGlobalDomain, useEnterprise: false},
+      'explicit',
       (grecaptcha) => {
         this.onloadCallback(grecaptcha);
       },


### PR DESCRIPTION
…ing configuration caused error on $ ng build

 Error: projects/ngx-captcha-lib/src/lib/components/base-recaptcha.component.ts:317:7 - error TS2559: Type 'boolean' has no properties in common with type 'RecaptchaConfiguration'.

      317       this.useGlobalDomain,
                ~~~~~~~~~~~~~~~~~~~~